### PR TITLE
Requires whitespace between "hubot help" and the query

### DIFF
--- a/src/help.coffee
+++ b/src/help.coffee
@@ -53,7 +53,7 @@ helpContents = (name, commands) ->
   """
 
 module.exports = (robot) ->
-  robot.respond /help\s*(.*)?$/i, (msg) ->
+  robot.respond /help\s+(.*)?$/i, (msg) ->
     cmds = renamedHelpCommands(robot)
     filter = msg.match[1]
 


### PR DESCRIPTION
We tried to add a command "!helpdesk" to our Hubot, but the regular expression in hubot-help also matched. It seems like this was maybe unintentional.
